### PR TITLE
Npm versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ jobs:
       node_js: 6
       script: npm run build
       before_deploy:
-      - npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
-      - git config --global user.email $(git log --pretty=format:"%ae" -n1)
-      - git config --global user.name $(git log --pretty=format:"%an" -n1)
+      - npm --no-git-tag-version version $($(npm bin)/json -f package.json version).$(date +%Y%m%d%H%M%S)
       deploy:
         provider: npm
         skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ jobs:
       node_js: 6
       script: npm run build
       before_deploy:
-      - npm --no-git-tag-version version $($(npm bin)/json -f package.json version).$(date +%Y%m%d%H%M%S)
+      - VPKG=$($(npm bin)/json -f package.json version)
+      - export VERSION=${VPKG/%?/}$(date +%Y%m%d%H%M%S)
+      - npm --no-git-tag-version version $VERSION
       deploy:
         provider: npm
         skip_cleanup: true
         email: $NPM_EMAIL
         api_key: $NPM_TOKEN
-        
+        on:
+          all_branches: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-l10n",
-  "version": "0.1.0",
+  "version": "0.1",
   "description": "Localization for the Scratch 3.0 components",
   "main": "./dist/l10n.js",
   "scripts": {
@@ -31,6 +31,7 @@
     "eslint-config-scratch": "^4.0.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-json": "1.2.0",
+    "json": "^9.0.6",
     "lodash.defaultsdeep": "4.6.0",
     "mkdirp": "^0.5.1",
     "react-intl": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-l10n",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Localization for the Scratch 3.0 components",
   "main": "./dist/l10n.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-l10n",
-  "version": "0.1",
+  "version": "0.1.0",
   "description": "Localization for the Scratch 3.0 components",
   "main": "./dist/l10n.js",
   "scripts": {


### PR DESCRIPTION
Use a date-time stamp for the patch version. It'll make it easier to know when translations have been updated (the most common type of release)

Bump major version to 1.0 to start using this in scratch-gui.