### PR TITLE
Build all the data before publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# transifex
+/.tx

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "npm run clean && npm run build:data && webpack --progress --colors --bail",
     "clean": "rimraf ./dist ./locales && mkdirp dist locales",
     "lint": "eslint . --ext .js,.json",
-    "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "npm run clean && npm run build:data && webpack --progress --colors --bail",
     "clean": "rimraf ./dist ./locales && mkdirp dist locales",
     "lint": "eslint . --ext .js,.json",
+    "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run build"
   },
   "repository": {


### PR DESCRIPTION
Need the built artifacts to use it. Was trying to decide between `prepublishOnly` and `prepare` (see https://docs.npmjs.com/misc/scripts#prepublish-and-prepare). prepublishOnly looks like the correct solution as the packages needed to build are all just dev dependencies.