### PR TITLE
Add scratch-paint

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -6,3 +6,8 @@ file_filter = gui/<lang>.json
 source_file = gui/en.json
 source_lang = en
 type = CHROME
+[experimental-scratch.scratch-paint]
+file_filter = paint/<lang>.json
+source_file = paint/en.json
+source_lang = en
+type = CHROME

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-l10n",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Localization for the Scratch 3.0 components",
   "main": "./dist/l10n.js",
   "scripts": {

--- a/paint/ar.json
+++ b/paint/ar.json
@@ -1,0 +1,62 @@
+{
+    "paint.paintEditor.fill": {
+        "message": "Fill",
+        "description": "Label for the color picker for the fill color"
+    },
+    "paint.eraserMode.eraser": {
+        "message": "Eraser",
+        "description": "Label for the eraser tool"
+    },
+    "paint.penMode.pen": {
+        "message": "Pen",
+        "description": "Label for the pen tool, which draws outlines"
+    },
+    "paint.paintEditor.saturation": {
+        "message": "Saturation",
+        "description": "Label for the saturation component in the color picker"
+    },
+    "paint.roundedRectMode.roundedRect": {
+        "message": "Rounded Rectangle",
+        "description": "Label for the rounded rectangle tool"
+    },
+    "paint.brushMode.brush": {
+        "message": "Brush",
+        "description": "Label for the brush tool"
+    },
+    "paint.lineMode.line": {
+        "message": "Line",
+        "description": "Label for the line tool, which draws straight line segments"
+    },
+    "paint.reshapeMode.reshape": {
+        "message": "Reshape",
+        "description": "Label for the reshape tool, which allows changing the points in the lines of the vectors"
+    },
+    "paint.paintEditor.brightness": {
+        "message": "Brightness",
+        "description": "Label for the brightness component in the color picker"
+    },
+    "paint.paintEditor.costume": {
+        "message": "Costume",
+        "description": "Label for the name of a sound"
+    },
+    "paint.rectMode.rect": {
+        "message": "Rectangle",
+        "description": "Label for the rectangle tool"
+    },
+    "paint.ovalMode.oval": {
+        "message": "Circle",
+        "description": "Label for the oval-drawing tool"
+    },
+    "paint.paintEditor.hue": {
+        "message": "Hue",
+        "description": "Label for the hue component in the color picker"
+    },
+    "paint.paintEditor.stroke": {
+        "message": "Outline",
+        "description": "Label for the color picker for the outline color"
+    },
+    "paint.selectMode.select": {
+        "message": "Select",
+        "description": "Label for the select tool, which allows selecting, moving, and resizing shapes"
+    }
+}

--- a/paint/de.json
+++ b/paint/de.json
@@ -1,0 +1,62 @@
+{
+    "paint.paintEditor.fill": {
+        "message": "Fill",
+        "description": "Label for the color picker for the fill color"
+    },
+    "paint.eraserMode.eraser": {
+        "message": "Eraser",
+        "description": "Label for the eraser tool"
+    },
+    "paint.penMode.pen": {
+        "message": "Pen",
+        "description": "Label for the pen tool, which draws outlines"
+    },
+    "paint.paintEditor.saturation": {
+        "message": "Saturation",
+        "description": "Label for the saturation component in the color picker"
+    },
+    "paint.roundedRectMode.roundedRect": {
+        "message": "Rounded Rectangle",
+        "description": "Label for the rounded rectangle tool"
+    },
+    "paint.brushMode.brush": {
+        "message": "Brush",
+        "description": "Label for the brush tool"
+    },
+    "paint.lineMode.line": {
+        "message": "Line",
+        "description": "Label for the line tool, which draws straight line segments"
+    },
+    "paint.reshapeMode.reshape": {
+        "message": "Reshape",
+        "description": "Label for the reshape tool, which allows changing the points in the lines of the vectors"
+    },
+    "paint.paintEditor.brightness": {
+        "message": "Brightness",
+        "description": "Label for the brightness component in the color picker"
+    },
+    "paint.paintEditor.costume": {
+        "message": "Costume",
+        "description": "Label for the name of a sound"
+    },
+    "paint.rectMode.rect": {
+        "message": "Rectangle",
+        "description": "Label for the rectangle tool"
+    },
+    "paint.ovalMode.oval": {
+        "message": "Circle",
+        "description": "Label for the oval-drawing tool"
+    },
+    "paint.paintEditor.hue": {
+        "message": "Hue",
+        "description": "Label for the hue component in the color picker"
+    },
+    "paint.paintEditor.stroke": {
+        "message": "Outline",
+        "description": "Label for the color picker for the outline color"
+    },
+    "paint.selectMode.select": {
+        "message": "Select",
+        "description": "Label for the select tool, which allows selecting, moving, and resizing shapes"
+    }
+}

--- a/paint/en.json
+++ b/paint/en.json
@@ -1,0 +1,62 @@
+{
+    "paint.paintEditor.fill": {
+        "message": "Fill",
+        "description": "Label for the color picker for the fill color"
+    },
+    "paint.eraserMode.eraser": {
+        "message": "Eraser",
+        "description": "Label for the eraser tool"
+    },
+    "paint.penMode.pen": {
+        "message": "Pen",
+        "description": "Label for the pen tool, which draws outlines"
+    },
+    "paint.paintEditor.saturation": {
+        "message": "Saturation",
+        "description": "Label for the saturation component in the color picker"
+    },
+    "paint.roundedRectMode.roundedRect": {
+        "message": "Rounded Rectangle",
+        "description": "Label for the rounded rectangle tool"
+    },
+    "paint.brushMode.brush": {
+        "message": "Brush",
+        "description": "Label for the brush tool"
+    },
+    "paint.lineMode.line": {
+        "message": "Line",
+        "description": "Label for the line tool, which draws straight line segments"
+    },
+    "paint.reshapeMode.reshape": {
+        "message": "Reshape",
+        "description": "Label for the reshape tool, which allows changing the points in the lines of the vectors"
+    },
+    "paint.paintEditor.brightness": {
+        "message": "Brightness",
+        "description": "Label for the brightness component in the color picker"
+    },
+    "paint.paintEditor.costume": {
+        "message": "Costume",
+        "description": "Label for the name of a sound"
+    },
+    "paint.rectMode.rect": {
+        "message": "Rectangle",
+        "description": "Label for the rectangle tool"
+    },
+    "paint.ovalMode.oval": {
+        "message": "Circle",
+        "description": "Label for the oval-drawing tool"
+    },
+    "paint.paintEditor.hue": {
+        "message": "Hue",
+        "description": "Label for the hue component in the color picker"
+    },
+    "paint.paintEditor.stroke": {
+        "message": "Outline",
+        "description": "Label for the color picker for the outline color"
+    },
+    "paint.selectMode.select": {
+        "message": "Select",
+        "description": "Label for the select tool, which allows selecting, moving, and resizing shapes"
+    }
+}

--- a/paint/es.json
+++ b/paint/es.json
@@ -1,0 +1,62 @@
+{
+    "paint.paintEditor.fill": {
+        "message": "Fill",
+        "description": "Label for the color picker for the fill color"
+    },
+    "paint.eraserMode.eraser": {
+        "message": "Eraser",
+        "description": "Label for the eraser tool"
+    },
+    "paint.penMode.pen": {
+        "message": "Pen",
+        "description": "Label for the pen tool, which draws outlines"
+    },
+    "paint.paintEditor.saturation": {
+        "message": "Saturation",
+        "description": "Label for the saturation component in the color picker"
+    },
+    "paint.roundedRectMode.roundedRect": {
+        "message": "Rounded Rectangle",
+        "description": "Label for the rounded rectangle tool"
+    },
+    "paint.brushMode.brush": {
+        "message": "Brush",
+        "description": "Label for the brush tool"
+    },
+    "paint.lineMode.line": {
+        "message": "Line",
+        "description": "Label for the line tool, which draws straight line segments"
+    },
+    "paint.reshapeMode.reshape": {
+        "message": "Reshape",
+        "description": "Label for the reshape tool, which allows changing the points in the lines of the vectors"
+    },
+    "paint.paintEditor.brightness": {
+        "message": "Brightness",
+        "description": "Label for the brightness component in the color picker"
+    },
+    "paint.paintEditor.costume": {
+        "message": "Costume",
+        "description": "Label for the name of a sound"
+    },
+    "paint.rectMode.rect": {
+        "message": "Rectangle",
+        "description": "Label for the rectangle tool"
+    },
+    "paint.ovalMode.oval": {
+        "message": "Circle",
+        "description": "Label for the oval-drawing tool"
+    },
+    "paint.paintEditor.hue": {
+        "message": "Hue",
+        "description": "Label for the hue component in the color picker"
+    },
+    "paint.paintEditor.stroke": {
+        "message": "Outline",
+        "description": "Label for the color picker for the outline color"
+    },
+    "paint.selectMode.select": {
+        "message": "Select",
+        "description": "Label for the select tool, which allows selecting, moving, and resizing shapes"
+    }
+}

--- a/paint/he.json
+++ b/paint/he.json
@@ -1,0 +1,62 @@
+{
+    "paint.paintEditor.fill": {
+        "message": "Fill",
+        "description": "Label for the color picker for the fill color"
+    },
+    "paint.eraserMode.eraser": {
+        "message": "Eraser",
+        "description": "Label for the eraser tool"
+    },
+    "paint.penMode.pen": {
+        "message": "Pen",
+        "description": "Label for the pen tool, which draws outlines"
+    },
+    "paint.paintEditor.saturation": {
+        "message": "Saturation",
+        "description": "Label for the saturation component in the color picker"
+    },
+    "paint.roundedRectMode.roundedRect": {
+        "message": "Rounded Rectangle",
+        "description": "Label for the rounded rectangle tool"
+    },
+    "paint.brushMode.brush": {
+        "message": "Brush",
+        "description": "Label for the brush tool"
+    },
+    "paint.lineMode.line": {
+        "message": "Line",
+        "description": "Label for the line tool, which draws straight line segments"
+    },
+    "paint.reshapeMode.reshape": {
+        "message": "Reshape",
+        "description": "Label for the reshape tool, which allows changing the points in the lines of the vectors"
+    },
+    "paint.paintEditor.brightness": {
+        "message": "Brightness",
+        "description": "Label for the brightness component in the color picker"
+    },
+    "paint.paintEditor.costume": {
+        "message": "Costume",
+        "description": "Label for the name of a sound"
+    },
+    "paint.rectMode.rect": {
+        "message": "Rectangle",
+        "description": "Label for the rectangle tool"
+    },
+    "paint.ovalMode.oval": {
+        "message": "Circle",
+        "description": "Label for the oval-drawing tool"
+    },
+    "paint.paintEditor.hue": {
+        "message": "Hue",
+        "description": "Label for the hue component in the color picker"
+    },
+    "paint.paintEditor.stroke": {
+        "message": "Outline",
+        "description": "Label for the color picker for the outline color"
+    },
+    "paint.selectMode.select": {
+        "message": "Select",
+        "description": "Label for the select tool, which allows selecting, moving, and resizing shapes"
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,15 @@ import ar from 'react-intl/locale-data/ar';
 import de from 'react-intl/locale-data/de';
 import es from 'react-intl/locale-data/es';
 import he from 'react-intl/locale-data/he';
+import locales from './supported-locales.js';
 
-import {locales} from '../locales/gui-msgs.js';
-
-locales.en.localeData = en;
-locales.ar.localeData = ar;
-locales.de.localeData = de;
-locales.es.localeData = es;
-locales.he.localeData = he;
+let localeData = locales;
+localeData.en.localeData = en;
+localeData.ar.localeData = ar;
+localeData.de.localeData = de;
+localeData.es.localeData = es;
+localeData.he.localeData = he;
 
 export {
-    locales as default
+    localeData as default
 };

--- a/src/supported-locales.js
+++ b/src/supported-locales.js
@@ -4,11 +4,11 @@
  */
 
 const locales = {
-    en: 'English',
-    ar: 'العربية',
-    de: 'Deutsch',
-    es: 'Español',
-    he: 'עִבְרִית'
+    en: {name: 'English'},
+    ar: {name: 'العربية'},
+    de: {name: 'Deutsch'},
+    es: {name: 'Español'},
+    he: {name: 'עִבְרִית'}
 };
 
 export {locales as default};


### PR DESCRIPTION
Breaking change - bumped major version to 2.

Restructured to support multiple components. Package default is just localeData for currently supported locales including the name for each language.

messages for each component are exported as separate files in locales. Clients of l10n will need to import messages for each of the compents used and combine them.