### PR TITLE
Exclude blocks messages from the combined file

### DIFF
--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -101,7 +101,6 @@ let blockData =
     ';\n';
 
 fs.writeFileSync(MSGS_DIR + 'blocks-msgs.js', blockData);
-defaultsDeep(editorMsgs, blocksMessages);
 
 // generate combined editor-msgs file
 let editorData =


### PR DESCRIPTION
Scratch-blocks includes the blocks messages. Excluding them from the editor-msgs file will save >500kb

This repo publishes a messages file that combines all the messages so gui only has to import one file. However, scratch-blocks needs it's own messages so currently the blocks translations are getting included twice (via l10n, and as the scratch-msgs.js file in scratch-blocks). 