### PR TITLE
Add RTL support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import gl from 'react-intl/locale-data/gl';
 import he from 'react-intl/locale-data/he';
 import hu from 'react-intl/locale-data/hu';
 import id from 'react-intl/locale-data/id';
+import is from 'react-intl/locale-data/is';
 import it from 'react-intl/locale-data/it';
 import ja from 'react-intl/locale-data/ja';
 import ko from 'react-intl/locale-data/ko';
@@ -35,7 +36,7 @@ import uk from 'react-intl/locale-data/uk';
 import vi from 'react-intl/locale-data/vi';
 import zh from 'react-intl/locale-data/zh';
 
-import locales, {customLocales} from './supported-locales.js';
+import locales, {customLocales, isRtl} from './supported-locales.js';
 /*
 locales = {
     'ab': {name: 'Аҧсшәа'},
@@ -85,6 +86,7 @@ let localeData = [].concat(
     he,
     hu,
     id,
+    is,
     it,
     ja,
     ko,
@@ -111,5 +113,6 @@ for (const lang in customLocales) {
 
 export {
     locales as default,
+    isRtl,
     localeData // data expected for initializing ReactIntl.addLocaleData
 };

--- a/src/supported-locales.js
+++ b/src/supported-locales.js
@@ -72,6 +72,15 @@ const customLocales = {
     }
 };
 
+// list of RTL locales supported, and a function to check whether a locale is RTL
+const rtlLocales = [
+    'he'
+];
+
+const isRtl = locale => {
+    return rtlLocales.indexOf(locale) !== -1;
+};
+
 const wwwLocales = {
     'ab': {name: 'Аҧсшәа'},
     'ar': {name: 'العربية'},
@@ -148,4 +157,4 @@ const wwwLocales = {
     'zh-tw': {name: '繁體中文'}
 };
 
-export {locales as default, customLocales, wwwLocales};
+export {locales as default, customLocales, rtlLocales, isRtl, wwwLocales};


### PR DESCRIPTION
Fixes #32 

- Maintain a list of RTL languages supported
- add `isRtl` method to check if a locale is RTL
- add icelandic to the menu and locale data.