### PR TITLE
Add l10n build failure notification to slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
 cache:
   directories:
   - node_modules
+notifications:
+  slack:
+    on_success: never
+    on_failure: $SLACK_NOTIFICATION_TOKEN
 jobs:
   include:
     - stage: update translations


### PR DESCRIPTION
Created a slack integration that posts to the scratch-ops channel and added the token as ENV variable in travis.

Configured the slack notification to only post on failure.
