### PR TITLE
import māori locale-data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ import ja from 'react-intl/locale-data/ja';
 import ko from 'react-intl/locale-data/ko';
 import lt from 'react-intl/locale-data/lt';
 import lv from 'react-intl/locale-data/lv';
+import mi from 'react-intl/locale-data/mi';
 import nl from 'react-intl/locale-data/nl';
 import nb from 'react-intl/locale-data/nb';
 import nn from 'react-intl/locale-data/nn';
@@ -113,6 +114,7 @@ let localeData = [].concat(
     ko,
     lt,
     lv,
+    mi,
     nl,
     nb,
     nn,

--- a/src/supported-locales.js
+++ b/src/supported-locales.js
@@ -65,14 +65,7 @@ const customLocales = {
         locale: 'ab',
         parentLocale: 'az'
     },
-    'es-419': {
-        locale: 'es-419',
-        parentLocale: 'es'
-    },
-    'mi': {
-        locale: 'mi',
-        parentLocale: 'en'
-    },
+    // TODO: replace zh-cn, zh-tw with zh-Hans and zh-Hant
     'zh-cn': {
         locale: 'zh-cn',
         parentLocale: 'zh'


### PR DESCRIPTION
### Proposed Changes
as of react-intl 2.8.0 māori (mi) locale data is included in `react-intl/locale-data`. Use that instead of a custom locale.

Also remove unnecessary `es-419` custom locale, `es-419` is already included in the default `es.js` locale-data.

### Testing

- [ ] make sure māori works in gui and www, can switch into and out of māori
- [ ] make sure latin american spanish works