### PR TITLE
Capitalize Belarusian in language menu

### DIFF
--- a/src/supported-locales.js
+++ b/src/supported-locales.js
@@ -9,7 +9,7 @@ const locales = {
     'am': {name: 'አማርኛ'},
     'az': {name: 'Azeri'},
     'id': {name: 'Bahasa Indonesia'},
-    'be': {name: 'беларуская'},
+    'be': {name: 'Беларуская'},
     'bg': {name: 'Български'},
     'ca': {name: 'Català'},
     'cs': {name: 'Česky'},


### PR DESCRIPTION
It should match other languages

Belarusian translator messaged me in transifex and provided a new string with the name capitalized.