### PR TITLE
Update circle-ci config to pull translations daily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,10 @@ workflows:
           filters:
             branches:
               only: tx-pull-manual
-  weekly-tx-pull:
+  daily-tx-pull:
       triggers:
-        - schedule: # weekly on Wednesday at 3am
-            cron: "0 3 * * 3"
+        - schedule: # daily at 3am UTC (10pm EST)
+            cron: "0 3 * * *"
             filters:
               branches:
                 only: master
@@ -123,7 +123,7 @@ workflows:
               - pull-translations # don't commit if there were errors
   daily-help-update:
     triggers:
-      - schedule: # daily at 5am
+      - schedule: # daily at 5am UTC
           cron: "0 5 * * *"
           filters:
             branches:


### PR DESCRIPTION
Change the frequency of the job that pulls translations for the editor and www so that the staging server translations are updated more often, and we know earlier if there are translation problems.

Clarify that the time in the cron jobs is UTC, not local.

### Resolves

- Resolves #126 

### Proposed Changes

Changes the schedule for the circle-ci cron job and clarifies that the time is UTC, not local.

No update of translations in this PR.