### PR TITLE
Modify push script to create non-existent resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2828,7 +2828,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4442,7 +4442,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -4953,7 +4953,7 @@
       "dependencies": {
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
@@ -4962,7 +4962,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -4998,7 +4998,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5079,7 +5079,7 @@
         },
         "espree": {
           "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
@@ -5124,7 +5124,7 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
@@ -5154,7 +5154,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -5166,7 +5166,7 @@
         },
         "progress": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true
         },
@@ -5218,7 +5218,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -5241,7 +5241,7 @@
         },
         "table": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
           "dev": true,
           "requires": {
@@ -6694,7 +6694,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -6728,7 +6728,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -6755,7 +6755,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -7037,7 +7037,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -7079,7 +7079,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -7087,7 +7087,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -7454,7 +7454,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -7471,7 +7471,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -7846,7 +7846,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -8737,7 +8737,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8805,7 +8805,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {

--- a/scripts/tx-push-src.js
+++ b/scripts/tx-push-src.js
@@ -41,11 +41,68 @@ const TX = new transifex({
 let en = fs.readFileSync(path.resolve(args[2]));
 en = JSON.parse(en);
 
+// get the correct resource file type based on transifex project/repo and resource
+const getResourceType = (project, resource) => {
+    if (project === 'scratch-website') {
+        // all the resources are KEYVALUEJSON
+        return 'KEYVALUEJSON';
+    }
+    if (project === 'scratch-legacy') {
+        // all the resources are po files
+        return 'PO';
+    }
+    if (project === 'scratch-editor') {
+        if (resource === 'blocks') {
+            return 'KEYVALUEJSON';
+        }
+        // everything else is CHROME I18N JSON
+        return 'CHROME';
+    }
+    if (project === 'scratch-videos') {
+        // all the resources are srt files
+        return 'SRT';
+    }
+    if (project === 'scratch-android') {
+        // all the resources are android xml files
+        return 'ANDROID';
+    }
+    if (project === 'scratch-resources') {
+        // all the resources are Chrome format json files
+        return 'CHROME';
+    }
+    process.stdout.write(`Error - Unknown resource type for:\n`);
+    process.stdout.write(`  Project: ${project}, resource: ${resource}\n`);
+    process.exit(1);
+};
+
 // update Transifex with English source
 TX.uploadSourceLanguageMethod(PROJECT, RESOURCE, {content: JSON.stringify(en)}, (err) => {
-    if (err) {
-        console.error(err); // eslint-disable-line no-console
-        process.exit(1);
+    if (err && err.response.statusCode !== 404) {
+        process.stdout.write(`Transifex Error: ${err.message}\n`);
+        process.stdout.write(
+            `Transifex Error ${err.response.statusCode.toString()}: ${err.response.body}\n`);
+        process.exitCode = 1;
+        return;
     }
-    process.exit(0);
+    // file not found - create it, but also give message
+    if (err && err.response.statusCode === 404) {
+        process.stdout.write(`Transifex Resource not found, creating: ${RESOURCE}\n`);
+        const resourceData = {
+            slug: RESOURCE,
+            name: RESOURCE,
+            priority: 0, // default to normal priority
+            i18n_type: getResourceType(PROJECT, RESOURCE),
+            content: JSON.stringify(en)
+        };
+        TX.resourceCreateMethod(PROJECT, resourceData, (err1) => {
+            if (err1) {
+                process.stdout.write(`Transifex Error: ${err1.message}\n`);
+                process.stdout.write(
+                    `Transifex Error ${err1.response.statusCode.toString()}: ${err1.response.body}\n`);
+                process.exitCode = 1;
+                return;
+            }
+        });
+    }
+    process.exitCode = 0;
 });


### PR DESCRIPTION
### Resolves

- Resolves #128 

### Proposed Changes

When trying to update a resource on transifex, it catches the file not found response and tries to create it instead.

This required adding a function that will return the correct file type for the resource based on the repository. Note, it will fail for new repositories. Also switched to using process.exitCode instead of process.exit to give async calls opportunity to finish.

Also checking in package lock changes, although they appear to be just changing. `http` to `https`

### Testing
I linked my local copy of www (develop branch) to the new version of l10n, then ran `npm run i18n:push`. The www script runs `tx-push-src` for all l10n files in www. Here's the output. Note that annual-report got the message about creating the resource instead of a 404 error:
```
$ npm run i18n:push

> www@1.0.0 i18n:push /Users/chrisg/Dev/scratch-www
> ./bin/tx-push-www --execute

pushing to transifex...
running command: $(npm bin)/tx-push-src scratch-website general-l10njson src/l10n.json
running command: $(npm bin)/tx-push-src scratch-website about-l10njson src/views/about/l10n.json
running command: $(npm bin)/tx-push-src scratch-website annual-report-l10njson src/views/annual-report/l10n.json
Transifex Resource not found, creating: annual-report-l10njson
running command: $(npm bin)/tx-push-src scratch-website boost-l10njson src/views/boost/l10n.json
running command: $(npm bin)/tx-push-src scratch-website camp-l10njson src/views/camp/l10n.json
...
```

