### PR TITLE
Rename 'Español' to 'Español (España)'

### DIFF
--- a/src/supported-locales.js
+++ b/src/supported-locales.js
@@ -20,7 +20,7 @@ const locales = {
     'et': {name: 'Eesti'},
     'el': {name: 'Ελληνικά'},
     'en': {name: 'English'},
-    'es': {name: 'Español'},
+    'es': {name: 'Español (España)'},
     'es-419': {name: 'Español Latinoamericano'},
     'eu': {name: 'Euskara'},
     'fa': {name: 'فارسی'},


### PR DESCRIPTION
### Resolves

- Resolves #142 

### Proposed Changes

Renames the entry for Spanish to indicate that it's the Spain version of Spanish.
