### PR TITLE
CE-180: Push source strings with Transifex v3 API

### DIFF
--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -104,4 +104,61 @@ const txResources = async function (project) {
     return slugs;
 };
 
-module.exports = {txPull, txResources};
+/**
+ * Uploads English source strings to a resource in transifex
+ * @param {string} project - project slug (for example,  "scratch-editor")
+ * @param {string} resource - resource slug (for example,  "blocks")
+ * @param {object} sourceStrings - json of source strings
+ */
+const txPush = async function (project, resource, sourceStrings) {
+    const resourceObj = {
+        data: {
+            id: `o:${ORG_NAME}:p:${project}:r:${resource}`,
+            type: 'resources'
+        }
+    };
+
+    await transifexApi.ResourceStringsAsyncUpload.upload({
+        resource: resourceObj,
+        content: JSON.stringify(sourceStrings)
+    });
+};
+
+/**
+ * Creates a new resource, and then uploads source strings to it if they are provided
+ * @param {*} project - project slug (for example,  "scratch-editor")
+ * @param {*} param1
+ *  - slug - resource slug
+ *  - name - resource name
+ *  - i18nType - i18n format id
+ *  - sourceStrings - json object of source strings
+ */
+const txCreateResource = async function (project, {slug, name, i18nType, sourceStrings}) {
+    const i18nFormat = {
+        data: {
+            id: i18nType || 'KEYVALUEJSON',
+            type: 'i18n_formats'
+        }
+    };
+
+    const projectObj = {
+        data: {
+            id: `o:${ORG_NAME}:p:${project}`,
+            type: 'projects'
+        }
+    };
+
+    await transifexApi.Resource.create({
+        attributes: {slug: slug, name: name},
+        relationships: {
+            i18n_format: i18nFormat,
+            project: projectObj
+        }
+    });
+
+    if (sourceStrings) {
+        await txPush(project, slug, sourceStrings);
+    }
+};
+
+module.exports = {txPull, txPush, txResources, txCreateResource};

--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -3,7 +3,6 @@
 /**
  * @fileoverview
  * Utilities for interfacing with Transifex API 3.
- * TODO: add functions for pushing to Transifex
  */
 
 const transifexApi = require('@transifex/api').transifexApi;
@@ -126,12 +125,12 @@ const txPush = async function (project, resource, sourceStrings) {
 
 /**
  * Creates a new resource, and then uploads source strings to it if they are provided
- * @param {*} project - project slug (for example,  "scratch-editor")
- * @param {*} param1
- *  - slug - resource slug
- *  - name - resource name
- *  - i18nType - i18n format id
- *  - sourceStrings - json object of source strings
+ * @param {string} project - project slug (for example,  "scratch-editor")
+ * @param {object} resource - object of resource information
+ * @param {string} resource.slug - resource slug (for example,  "blocks")
+ * @param {string} resource.name - resource name
+ * @param {string} resource.i18nType - i18n format id
+ * @param {object} resource.sourceStrings - json object of source strings
  */
 const txCreateResource = async function (project, {slug, name, i18nType, sourceStrings}) {
     const i18nFormat = {

--- a/scripts/tx-push-src.js
+++ b/scripts/tx-push-src.js
@@ -84,17 +84,15 @@ const pushSource = async function () {
             return;
         }
         // file not found - create it, but also give message
-        if (err.statusCode === 404) {
-            process.stdout.write(`Transifex Resource not found, creating: ${RESOURCE}\n`);
-            const resourceData = {
-                slug: RESOURCE,
-                name: RESOURCE,
-                priority: 0, // default to normal priority
-                i18nType: getResourceType(PROJECT, RESOURCE),
-                content: en
-            };
-            await txCreateResource(PROJECT, resourceData);
-        }
+        process.stdout.write(`Transifex Resource not found, creating: ${RESOURCE}\n`);
+        const resourceData = {
+            slug: RESOURCE,
+            name: RESOURCE,
+            priority: 0, // default to normal priority
+            i18nType: getResourceType(PROJECT, RESOURCE),
+            content: en
+        };
+        await txCreateResource(PROJECT, resourceData);
         process.exitCode = 0;
     }
 };

--- a/scripts/tx-push-src.js
+++ b/scripts/tx-push-src.js
@@ -10,8 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const txPush = require('../lib/transifex.js').txPush;
-const txCreateResource = require('../lib/transifex.js').txCreateResource;
+const {txPush, txCreateResource} = require('../lib/transifex.js');
 
 const args = process.argv.slice(2);
 


### PR DESCRIPTION
### Resolves

- Resolves #171 and CE-180

### Proposed Changes

This PR is a rebased version of #162, modifying the `tx-push-src` script to use the Transifex v3 API. There should be no breaking API changes introduced in this PR, and it has been tested from within `scratch-www` and seems to work as expected.

### What this PR does not change
The scripts for pushing and pulling help article strings will be migrated to the new API in a followup PR (#176).