### PR TITLE
WIP CE-180: push help article strings

### DIFF
--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -104,6 +104,35 @@ const txResources = async function (project) {
 };
 
 /**
+ * @param {string} project - project slug (for example)
+ * @returns {object[]} - array of resource objects
+ */
+const txResourcesObjects = async function (project) {
+    const resources = await transifexApi.Resource.filter({
+        project: `o:${ORG_NAME}:p:${project}`
+    });
+
+    await resources.fetch();
+    return resources.data;
+};
+
+/**
+ * Gets available languages for a project
+ * @param {string} slug - project slug (for example, "scratch-editor")
+ * @returns {Promise<string[]>} - list of language codes
+ */
+const txAvailableLanguages = async function (slug) {
+    const project = await transifexApi.Project.get({
+        organization: `o:${ORG_NAME}`,
+        slug: slug
+    });
+
+    const languages = await project.fetch('languages');
+    return languages.data.map(l => l.code);
+
+};
+
+/**
  * Uploads English source strings to a resource in transifex
  * @param {string} project - project slug (for example,  "scratch-editor")
  * @param {string} resource - resource slug (for example,  "blocks")
@@ -160,4 +189,4 @@ const txCreateResource = async function (project, {slug, name, i18nType, sourceS
     }
 };
 
-module.exports = {txPull, txPush, txResources, txCreateResource};
+module.exports = {txPull, txPush, txResources, txResourcesObjects, txCreateResource, txAvailableLanguages};

--- a/scripts/tx-push-help.js
+++ b/scripts/tx-push-help.js
@@ -63,6 +63,7 @@ const txPushResource = async (name, articles, type) => {
         }
 
         // file not found - create it, but also give message
+        process.stdout.write(`Transifex Resource not found, creating: ${name}\n`);
         if (err.statusCode === 404) {
             await txCreateResource(TX_PROJECT, resourceData);
         }

--- a/scripts/tx-push-help.js
+++ b/scripts/tx-push-help.js
@@ -6,6 +6,7 @@
  */
 
 const args = process.argv.slice(2);
+const {txPush, txCreateResource} = require('../lib/transifex.js');
 
 const usage = `
  Pull knowledge base articles from Freshdesk and push to scratch-help project on transifex. Usage:
@@ -22,15 +23,10 @@ if (!process.env.TX_TOKEN || !process.env.FRESHDESK_TOKEN || args.length > 0) {
     process.exit(1);
 }
 
-import transifex from 'transifex';
 import FreshdeskApi from './freshdesk-api.js';
 
 const FD = new FreshdeskApi('https://mitscratch.freshdesk.com', process.env.FRESHDESK_TOKEN);
 const TX_PROJECT = 'scratch-help';
-const TX = new transifex({
-    project_slug: TX_PROJECT,
-    credential: 'api:' + process.env.TX_TOKEN
-});
 
 const categoryNames = {};
 const folderNames = {};
@@ -46,33 +42,31 @@ const makeTxId = item => {
     return `${item.name.replace(/[ /]/g, '').slice(0, 30)}_${item.id}`;
 };
 
-const txPushResource = (name, articles, type) => {
+const txPushResource = async (name, articles, type) => {
     const resourceData = {
         slug: name,
         name: name,
-        priority: 0, // default to normal priority
         i18n_type: type,
-        content: '{}'
+        priority: 0, // default to normal priority
+        content: articles
     };
-    TX.resourceCreateMethod(TX_PROJECT, resourceData, (err) => {
-        // ignore already created error report others
-        if (err && err.response.statusCode !== 400) {
+
+    try {
+        await txPush(TX_PROJECT, name, articles);
+    } catch (err) {
+        if (err.statusCode !== 404) {
             process.stdout.write(`Transifex Error: ${err.message}\n`);
             process.stdout.write(
                 `Transifex Error ${err.response.statusCode.toString()}: ${err.response.body}\n`);
             process.exitCode = 1;
             return;
         }
-        // update Transifex with English source
-        TX.uploadSourceLanguageMethod(TX_PROJECT, name,
-            {content: JSON.stringify(articles, null, 2)}, (err1) => {
-                if (err1) {
-                    process.stdout.write(`Transifex Error:${err1.name}, ${err1.message}\n`);
-                    process.stdout.write(`Transifex Error:${err1.toString()}\n`);
-                    process.exitCode = 1;
-                }
-            });
-    });
+
+        // file not found - create it, but also give message
+        if (err.statusCode === 404) {
+            await txCreateResource(TX_PROJECT, resourceData);
+        }
+    }
 };
 
 /**


### PR DESCRIPTION
### Resolves

- Resolves #171 and CE-180

### Proposed Changes

This PR is a followup to #175 which updates the help string utils to use the v3 transifex API helper functions introduced in that PR. This PR also adds some new helper functions, `txResourcesObjects` and `txAvailableLanguages` to maintain identical functionality to the v2 API help string utils. The only new commits in this PR are 58a408e6663ff03e0f4d5903759021c7413e2d08 and d39eddebc2930765c18c4f5883ba40c4bae73b45.