### PR TITLE
Fix txAvailableLanguages

### DIFF
--- a/lib/transifex.js
+++ b/lib/transifex.js
@@ -128,7 +128,8 @@ const txAvailableLanguages = async function (slug) {
     });
 
     const languages = await project.fetch('languages');
-    return languages.data.map(l => l.code);
+    await languages.fetch();
+    return languages.data.map(l => l.attributes.code);
 
 };
 


### PR DESCRIPTION
### Resolves
- the `sync-help` job on circleci was always failing with an `Error: Cannot read properties of null (reading 'map') error`, which it turns out was a result of `txAvailableLanguages` not returning anything. The cause of this was that the transifex v3 api apparently requires you to run `.fetch()` on the object that's returned from `project.fetch('languages')`.

### Proposed Changes

- runs `languages.fetch()` before getting language codes
- gets language code with `l.attributes.code` instead of `l.code`
